### PR TITLE
Update pom.xml to fix Jitpack compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <description>The modern "apartment" plugin for Towny</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <url>https://earthmc.net</url>
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
The current pom.xml sets the Java compilation version as 8, which causes the plugin to [fail all builds](https://jitpack.io/com/github/Fruitloopins/Quarters/-3bc3ea431e-1/build.log) on Jitpack and prevents it from being used as a dependency. 

Here is the relevant part of the Jitpack build log:
```
[ERROR]   bad class file: /home/jitpack/.m2/repository/io/papermc/paper/paper-api/1.20.1-R0.1-SNAPSHOT/paper-api-1.20.1-R0.1-SNAPSHOT.jar(org/bukkit/Location.class)
[ERROR]     class file has wrong version 61.0, should be 52.0
```

This PR changes the Java compilation version to 17, which [fixes the issue](https://jitpack.io/#galacticwarrior9/Quarters/update-pom-3b35d6e0d2-1). 