### PR TITLE
Fix towny artifact not being found when building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,17 +25,17 @@ repositories {
     }
 
     maven {
-        url = "https://jitpack.io"
+        url = "https://repo.extendedclip.com/content/repositories/placeholderapi/"
     }
 
     maven {
-        url = "https://repo.extendedclip.com/content/repositories/placeholderapi/"
+        url = "https://repo.glaremasters.me/repository/towny/"
     }
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
-    compileOnly("com.github.TownyAdvanced:Towny:0.100.3.0")
+    compileOnly("com.palmergames.bukkit.towny:towny:0.101.0.0")
     compileOnly("me.clip:placeholderapi:2.11.6")
 }
 


### PR DESCRIPTION
Replaces the jitpack repo with glare's repo, since it was having trouble finding the dependency there